### PR TITLE
Use "nanoid" for request id

### DIFF
--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@dfinity/verifiable-credentials",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "jose": "^5.2.4"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.7",
@@ -3669,6 +3672,14 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.4.tgz",
+      "integrity": "sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -8,6 +8,10 @@
       "name": "@dfinity/verifiable-credentials",
       "version": "0.0.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@types/uuid": "^9.0.8",
+        "uuid": "^9.0.1"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.7",
@@ -1023,6 +1027,11 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
+      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -5154,6 +5163,18 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@dfinity/verifiable-credentials",
       "version": "0.0.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "jose": "^5.2.4"
-      },
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.7",
@@ -3672,14 +3669,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jose": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.4.tgz",
-      "integrity": "sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {

--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/uuid": "^9.0.8",
-        "uuid": "^9.0.1"
+        "nanoid": "^5.0.7"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -1027,11 +1026,6 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -3960,10 +3954,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
+      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
       "funding": [
         {
           "type": "github",
@@ -3971,10 +3964,10 @@
         }
       ],
       "bin": {
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
       },
       "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^18 || >=20"
       }
     },
     "node_modules/natural-compare": {
@@ -4279,6 +4272,24 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -5163,18 +5174,6 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -70,7 +70,6 @@
     "vitest": "^1.5.0"
   },
   "dependencies": {
-    "@types/uuid": "^9.0.8",
-    "uuid": "^9.0.1"
+    "nanoid": "^5.0.7"
   }
 }

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -69,5 +69,8 @@
     "typescript": "^5.4.5",
     "vitest": "^1.5.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "@types/uuid": "^9.0.8",
+    "uuid": "^9.0.1"
+  }
 }

--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -39,9 +39,7 @@ export type CredentialsRequest = {
  */
 // TODO: Support multiple flows at the same time.
 let iiWindow: Window | null = null;
-const createFlowId = (): FlowId => {
-  return nanoid();
-};
+const createFlowId = (): FlowId => nanoid();
 
 type FlowId = string;
 const currentFlows = new Set<FlowId>();

--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from "uuid";
+
 /**
  * Helper types.
  */
@@ -20,7 +22,7 @@ export type IssuerData = {
 };
 const VC_REQUEST_METHOD = "request_credential";
 const JSON_RPC_VERSION = "2.0";
-type CredentialsRequest = {
+export type CredentialsRequest = {
   id: FlowId;
   jsonrpc: typeof JSON_RPC_VERSION;
   method: typeof VC_REQUEST_METHOD;
@@ -35,19 +37,10 @@ type CredentialsRequest = {
 /**
  * Helper functions
  */
-
-// Needed to reset the flow id between tests.
-// TODO: Remove this when using UUIDs.
-export const resetNextFlowId = () => {
-  nextFlowIdCounter = 0;
-};
 // TODO: Support multiple flows at the same time.
 let iiWindow: Window | null = null;
-// TODO: Use UUIDs instead of incrementing integers.
-let nextFlowIdCounter = 0;
 const createFlowId = (): FlowId => {
-  nextFlowIdCounter += 1;
-  return String(nextFlowIdCounter);
+  return uuidv4();
 };
 
 type FlowId = string;

--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from "uuid";
+import { nanoid } from "nanoid";
 
 /**
  * Helper types.
@@ -40,7 +40,7 @@ export type CredentialsRequest = {
 // TODO: Support multiple flows at the same time.
 let iiWindow: Window | null = null;
 const createFlowId = (): FlowId => {
-  return uuidv4();
+  return nanoid();
 };
 
 type FlowId = string;

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -249,6 +249,40 @@ describe("Request Verifiable Credentials function", () => {
       mockMessageFromIdentityProvider(noCredential);
     }));
 
+  it("calls onError if decoding credential fails", async () =>
+    new Promise<void>((done) => {
+      requestVerifiablePresentation({
+        onSuccess: unreachableFn,
+        onError: (err: string) => {
+          expect(err).toBe(
+            "Error getting the verifiable credential: Decoding credentials failed: JWTInvalid: Invalid JWT",
+          );
+          done();
+        },
+        credentialData: {
+          credentialSpec: {
+            credentialType: "MembershipCredential",
+            arguments: {
+              organization: "DFINITY",
+            },
+          },
+          credentialSubject,
+        },
+        issuerData: {
+          origin: issuerOrigin,
+        },
+        derivationOrigin: undefined,
+        identityProvider,
+      });
+      mockMessageFromIdentityProvider(VcFlowReady);
+      mockMessageFromIdentityProvider({
+        ...vcVerifiablePresentationMessageSuccess,
+        result: {
+          verifiablePresentation: "invalid",
+        },
+      });
+    }));
+
   // TODO: Add functionality after refactor.
   it.skip("ignores messages from other origins than identity provider", () =>
     new Promise<void>((done) => done()));

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -41,7 +41,6 @@ describe("Request Verifiable Credentials function", () => {
     credentialSubject,
   };
 
-  const credentialPresentationSuccess = credentialPresentationMock;
   const unreachableFn = () => {
     expect.unreachable("this function should not be called");
   };

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -241,31 +241,6 @@ describe("Request Verifiable Credentials function", () => {
     );
   });
 
-  it("calls onError if decoding credential fails", async () => {
-    const onError = vi.fn();
-    requestVerifiablePresentation({
-      onSuccess: unreachableFn,
-      onError,
-      credentialData,
-      issuerData,
-      derivationOrigin: undefined,
-      identityProvider,
-    });
-    const {
-      request: { id },
-    } = await startVcFlow();
-    mockMessageFromIdentityProvider({
-      id,
-      result: {
-        verifiablePresentation: "invalid",
-      },
-    });
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(
-      "Error getting the verifiable credential: Decoding credentials failed: JWTInvalid: Invalid JWT",
-    );
-  });
-
   // TODO: Add functionality after refactor.
   it.skip("ignores messages from other origins than identity provider", () =>
     new Promise<void>((done) => done()));

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -1,8 +1,8 @@
 import { vi } from "vitest";
 import {
   requestVerifiablePresentation,
-  resetNextFlowId,
   type CredentialRequestData,
+  type CredentialsRequest,
 } from "../request-verifiable-presentation";
 import { credentialPresentationMock } from "./mocks";
 
@@ -15,28 +15,22 @@ describe("Request Verifiable Credentials function", () => {
   const issuerData = {
     origin: issuerOrigin,
   };
-
   // Source: https://github.com/dfinity/internet-identity/blob/6df217532c7e3d4d465decbd9159ceab5262ba2d/src/vc-api/src/index.ts#L9
   const VcFlowReady = {
     jsonrpc: "2.0",
     method: "vc-flow-ready",
   };
-  const expectedFlowId = "1";
-  const vcVerifiablePresentationMessageSuccess = {
-    // id should match the received id.
-    // We know it starts with 1 because nextFlowId is incremented before the request is sent.
-    // Ideally, we would record the one sent from the request and use it here.
-    // TODO: Record the id passed in the reply to the first call and use it here.
-    id: expectedFlowId,
+  const vcVerifiablePresentationMessageSuccess = (id: string) => ({
+    id,
     jsonrpc: "2.0",
     result: {
       verifiablePresentation: credentialPresentationMock,
     },
-  };
-  const vcVerifiablePresentationMessageError = {
-    id: "1",
+  });
+  const vcVerifiablePresentationMessageError = (id: string) => ({
+    id,
     error: "Error getting the verifiable credential",
-  };
+  });
   const credentialData: CredentialRequestData = {
     credentialSpec: {
       credentialType: "MembershipCredential",
@@ -48,206 +42,229 @@ describe("Request Verifiable Credentials function", () => {
   };
 
   const credentialPresentationSuccess = credentialPresentationMock;
-
-  let sourcePostMessageSpy;
   const unreachableFn = () => {
     expect.unreachable("this function should not be called");
   };
 
   beforeEach(() => {
     window.open = vi.fn();
-    sourcePostMessageSpy = vi.fn();
-    resetNextFlowId();
   });
+
+  const startVcFlow = (): Promise<{
+    request: CredentialsRequest;
+    options: Record<string, string>;
+  }> => {
+    return new Promise((resolve) => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          source: {
+            postMessage: (
+              request: CredentialsRequest,
+              options: Record<string, string>,
+            ) => {
+              resolve({ request, options });
+            },
+          } as Window,
+          origin: identityProvider,
+          data: {
+            jsonrpc: "2.0",
+            method: "vc-flow-ready",
+          },
+        }),
+      );
+    });
+  };
 
   const mockMessageFromIdentityProvider = (data: unknown) => {
     window.dispatchEvent(
       new MessageEvent("message", {
         source: {
-          postMessage: sourcePostMessageSpy,
-        } as Window,
+          postMessage: vi.fn(),
+        } as unknown as Window,
         origin: identityProvider,
         data,
       }),
     );
   };
 
-  it("opens new window and calls onSuccess with a verifiable presentation", async () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: (presentation: string) => {
-          expect(presentation).toEqual(credentialPresentationSuccess);
-          done();
-        },
-        onError: unreachableFn,
-        credentialData,
-        issuerData,
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      expect(window.open).toHaveBeenCalledTimes(1);
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess);
-    }));
+  it("opens new window and calls onSuccess with a verifiable presentation", async () => {
+    const onSuccess = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess,
+      onError: unreachableFn,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider,
+    });
 
-  it("calls onSuccess with a verifiable presentation", async () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: (presentation: string) => {
-          expect(presentation).toEqual(credentialPresentationSuccess);
-          done();
-        },
-        onError: unreachableFn,
-        credentialData: {
-          credentialSpec: {
-            credentialType: "MembershipCredential",
-            arguments: {
-              organization: "DFINITY",
-            },
-          },
-          credentialSubject,
-        },
-        issuerData: {
-          origin: issuerOrigin,
-        },
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess);
-    }));
+    const {
+      request: { id },
+    } = await startVcFlow();
+    mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess(id));
 
-  it("send expected request to the identity provider with derivationOrigin", () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: () => {
-          expect(sourcePostMessageSpy).toHaveBeenCalledTimes(1);
-          expect(sourcePostMessageSpy).toHaveBeenCalledWith(
-            {
-              id: expectedFlowId,
-              jsonrpc: "2.0",
-              method: "request_credential",
-              params: {
-                issuer: issuerData,
-                credentialSpec: credentialData.credentialSpec,
-                credentialSubject,
-                derivationOrigin,
-              },
-            },
-            {
-              targetOrigin: identityProvider,
-            },
-          );
-          done();
-        },
-        onError: unreachableFn,
-        credentialData,
-        issuerData,
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toBeCalledWith(credentialPresentationMock);
+    expect(window.open).toHaveBeenCalledTimes(1);
+  });
+
+  it("send expected request to the identity provider with derivationOrigin", async () => {
+    const onSuccess = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess,
+      onError: unreachableFn,
+      credentialData,
+      issuerData,
+      derivationOrigin,
+      identityProvider,
+    });
+
+    const { request, options } = await startVcFlow();
+    mockMessageFromIdentityProvider(
+      vcVerifiablePresentationMessageSuccess(request.id),
+    );
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(request).toEqual({
+      id: expect.any(String),
+      jsonrpc: "2.0",
+      method: "request_credential",
+      params: {
+        issuer: issuerData,
+        credentialSpec: credentialData.credentialSpec,
+        credentialSubject,
         derivationOrigin,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess);
-    }));
+      },
+    });
+    expect(options).toEqual({ targetOrigin: identityProvider });
+  });
 
-  it("is successful with multiple flow-ready messages", async () =>
-    new Promise<void>((done) => {
-      const onError = vi.fn();
-      requestVerifiablePresentation({
-        onSuccess: (presentation: string) => {
-          expect(presentation).toEqual(credentialPresentationSuccess);
-          expect(onError).not.toHaveBeenCalled();
-          done();
-        },
-        onError: unreachableFn,
-        credentialData,
-        issuerData,
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess);
-    }));
+  it("is successful with multiple flow-ready messages", async () => {
+    const onSuccess = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess,
+      onError: unreachableFn,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider,
+    });
+    const {
+      request: { id },
+    } = await startVcFlow();
+    mockMessageFromIdentityProvider(VcFlowReady);
+    mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess(id));
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
 
-  it("waits until the expected id is received", () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: (presentation: string) => {
-          expect(presentation).toEqual(credentialPresentationSuccess);
-          done();
-        },
-        onError: unreachableFn,
-        credentialData,
-        issuerData,
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider({
-        id: "not-expected-id",
-        ...vcVerifiablePresentationMessageSuccess,
-      });
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess);
-    }));
+  it("waits until the expected id is received", async () => {
+    const onSuccess = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess,
+      onError: unreachableFn,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider,
+    });
+    const {
+      request: { id },
+    } = await startVcFlow();
+    mockMessageFromIdentityProvider(
+      vcVerifiablePresentationMessageSuccess("wrong-id"),
+    );
+    expect(onSuccess).not.toHaveBeenCalled();
+    mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess(id));
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
 
-  it("ignores messages before starting the flow", () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: (presentation: string) => {
-          expect(presentation).toEqual(credentialPresentationSuccess);
-          done();
-        },
-        onError: unreachableFn,
-        credentialData,
-        issuerData,
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      // This doesn't trigger an error because it's before the flow starts.
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageError);
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess);
-    }));
+  it("ignores messages before starting the flow", async () => {
+    const onSuccess = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess,
+      onError: unreachableFn,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider,
+    });
+    mockMessageFromIdentityProvider({
+      id: "1",
+      error: "Error getting the verifiable credential",
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+    const {
+      request: { id },
+    } = await startVcFlow();
+    mockMessageFromIdentityProvider(vcVerifiablePresentationMessageSuccess(id));
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
 
-  it("calls onError when the credential fails", () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: unreachableFn,
-        onError: (err: unknown) => {
-          expect(err).toEqual(
-            `Error getting the verifiable credential: ${vcVerifiablePresentationMessageError.error}`,
-          );
-          done();
-        },
-        credentialData,
-        issuerData,
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(vcVerifiablePresentationMessageError);
-    }));
+  it("calls onError when the credential fails", async () => {
+    const onError = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess: unreachableFn,
+      onError,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider,
+    });
+    const {
+      request: { id },
+    } = await startVcFlow();
+    mockMessageFromIdentityProvider(vcVerifiablePresentationMessageError(id));
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      `Error getting the verifiable credential: ${vcVerifiablePresentationMessageError("id").error}`,
+    );
+  });
 
-  it("calls onError when there is no verifiable presentation", () =>
-    new Promise<void>((done) => {
-      const noCredential = { id: "1", jsonrpc: "2.0" };
-      requestVerifiablePresentation({
-        onSuccess: unreachableFn,
-        onError: (err: unknown) => {
-          expect(err).toEqual(
-            `Error getting the verifiable credential: Key 'verifiablePresentation' not found in the message data: ${JSON.stringify(noCredential)}`,
-          );
-          done();
-        },
-        credentialData,
-        issuerData,
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider(noCredential);
-    }));
+  it("calls onError when there is no verifiable presentation", async () => {
+    const onError = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess: unreachableFn,
+      onError,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider,
+    });
+    const {
+      request: { id },
+    } = await startVcFlow();
+    const noCredential = { id, jsonrpc: "2.0" };
+    mockMessageFromIdentityProvider(noCredential);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      `Error getting the verifiable credential: Key 'verifiablePresentation' not found in the message data: ${JSON.stringify(noCredential)}`,
+    );
+  });
+
+  it("calls onError if decoding credential fails", async () => {
+    const onError = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess: unreachableFn,
+      onError,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider,
+    });
+    const {
+      request: { id },
+    } = await startVcFlow();
+    mockMessageFromIdentityProvider({
+      id,
+      result: {
+        verifiablePresentation: "invalid",
+      },
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      "Error getting the verifiable credential: Decoding credentials failed: JWTInvalid: Invalid JWT",
+    );
+  });
 
   // TODO: Add functionality after refactor.
   it.skip("ignores messages from other origins than identity provider", () =>

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -72,7 +72,7 @@ describe("Request Verifiable Credentials function", () => {
     );
   };
 
-  it.only("opens new window and calls onSuccess with a verifiable presentation", async () =>
+  it("opens new window and calls onSuccess with a verifiable presentation", async () =>
     new Promise<void>((done) => {
       requestVerifiablePresentation({
         onSuccess: (presentation: string) => {

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -249,40 +249,6 @@ describe("Request Verifiable Credentials function", () => {
       mockMessageFromIdentityProvider(noCredential);
     }));
 
-  it("calls onError if decoding credential fails", async () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: unreachableFn,
-        onError: (err: string) => {
-          expect(err).toBe(
-            "Error getting the verifiable credential: Decoding credentials failed: JWTInvalid: Invalid JWT",
-          );
-          done();
-        },
-        credentialData: {
-          credentialSpec: {
-            credentialType: "MembershipCredential",
-            arguments: {
-              organization: "DFINITY",
-            },
-          },
-          credentialSubject,
-        },
-        issuerData: {
-          origin: issuerOrigin,
-        },
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider({
-        ...vcVerifiablePresentationMessageSuccess,
-        result: {
-          verifiablePresentation: "invalid",
-        },
-      });
-    }));
-
   // TODO: Add functionality after refactor.
   it.skip("ignores messages from other origins than identity provider", () =>
     new Promise<void>((done) => done()));

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -72,7 +72,7 @@ describe("Request Verifiable Credentials function", () => {
     );
   };
 
-  it("opens new window and calls onSuccess with a verifiable presentation", async () =>
+  it.only("opens new window and calls onSuccess with a verifiable presentation", async () =>
     new Promise<void>((done) => {
       requestVerifiablePresentation({
         onSuccess: (presentation: string) => {


### PR DESCRIPTION
# Motivation

Use uuid to define the request id instead of a sequencial number.

# Changes

* Install `uuid` to create uuids.
* Create id with `uuid` library instead of variable `nextFlowIdCounter`.

# Tests

Test coverage is the same but I had to change the implementation to get the id when the flow starts.

Using the callback strategy was not nice; therefore, I reimplemented the tests to use `async` and `await` and added a helper `startVcFlow` that returns the request id.
