### PR TITLE
Support concurrent flows

### DIFF
--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -128,6 +128,7 @@ export const requestVerifiablePresentation = ({
       } finally {
         currentFlows.delete(evnt.data.id);
         iiWindows.get(nextFlowId)?.close();
+        iiWindows.delete(nextFlowId);
         window.removeEventListener("message", handleCurrentFlow);
       }
     }

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -15,7 +15,6 @@ describe("Request Verifiable Credentials function", () => {
   const issuerData = {
     origin: issuerOrigin,
   };
-
   // Source: https://github.com/dfinity/internet-identity/blob/6df217532c7e3d4d465decbd9159ceab5262ba2d/src/vc-api/src/index.ts#L9
   const VcFlowReady = {
     jsonrpc: "2.0",

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -240,6 +240,40 @@ describe("Request Verifiable Credentials function", () => {
     );
   });
 
+  it("calls onError if decoding credential fails", async () =>
+    new Promise<void>((done) => {
+      requestVerifiablePresentation({
+        onSuccess: unreachableFn,
+        onError: (err: string) => {
+          expect(err).toBe(
+            "Error getting the verifiable credential: Decoding credentials failed: JWTInvalid: Invalid JWT",
+          );
+          done();
+        },
+        credentialData: {
+          credentialSpec: {
+            credentialType: "MembershipCredential",
+            arguments: {
+              organization: "DFINITY",
+            },
+          },
+          credentialSubject,
+        },
+        issuerData: {
+          origin: issuerOrigin,
+        },
+        derivationOrigin: undefined,
+        identityProvider,
+      });
+      mockMessageFromIdentityProvider(VcFlowReady);
+      mockMessageFromIdentityProvider({
+        ...vcVerifiablePresentationMessageSuccess,
+        result: {
+          verifiablePresentation: "invalid",
+        },
+      });
+    }));
+
   // TODO: Add functionality after refactor.
   it.skip("ignores messages from other origins than identity provider", () =>
     new Promise<void>((done) => done()));

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -240,40 +240,6 @@ describe("Request Verifiable Credentials function", () => {
     );
   });
 
-  it("calls onError if decoding credential fails", async () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: unreachableFn,
-        onError: (err: string) => {
-          expect(err).toBe(
-            "Error getting the verifiable credential: Decoding credentials failed: JWTInvalid: Invalid JWT",
-          );
-          done();
-        },
-        credentialData: {
-          credentialSpec: {
-            credentialType: "MembershipCredential",
-            arguments: {
-              organization: "DFINITY",
-            },
-          },
-          credentialSubject,
-        },
-        issuerData: {
-          origin: issuerOrigin,
-        },
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider({
-        ...vcVerifiablePresentationMessageSuccess,
-        result: {
-          verifiablePresentation: "invalid",
-        },
-      });
-    }));
-
   // TODO: Add functionality after refactor.
   it.skip("ignores messages from other origins than identity provider", () =>
     new Promise<void>((done) => done()));

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -241,40 +241,6 @@ describe("Request Verifiable Credentials function", () => {
     );
   });
 
-  it("calls onError if decoding credential fails", async () =>
-    new Promise<void>((done) => {
-      requestVerifiablePresentation({
-        onSuccess: unreachableFn,
-        onError: (err: string) => {
-          expect(err).toBe(
-            "Error getting the verifiable credential: Decoding credentials failed: JWTInvalid: Invalid JWT",
-          );
-          done();
-        },
-        credentialData: {
-          credentialSpec: {
-            credentialType: "MembershipCredential",
-            arguments: {
-              organization: "DFINITY",
-            },
-          },
-          credentialSubject,
-        },
-        issuerData: {
-          origin: issuerOrigin,
-        },
-        derivationOrigin: undefined,
-        identityProvider,
-      });
-      mockMessageFromIdentityProvider(VcFlowReady);
-      mockMessageFromIdentityProvider({
-        ...vcVerifiablePresentationMessageSuccess,
-        result: {
-          verifiablePresentation: "invalid",
-        },
-      });
-    }));
-
   // TODO: Add functionality after refactor.
   it.skip("ignores messages from other origins than identity provider", () =>
     new Promise<void>((done) => done()));


### PR DESCRIPTION
# Motivation

The main motivation is to allow the library to start multiple concurrent flows.

# Changes

* Store opened windows in a Map instead of one single instance.
* Pass the flowId to the helper instead of creating it inside the helper.
* Scope the flowId per handler so that each handler is about one flow.

# Tests

* Test that the function supports two concurrent flows.
