### PR TITLE
Workflow to publish a release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Release
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm install -g npm
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test
+      - name: Set up npm
+        run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,8 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
-      - run: npm install -g npm
       - name: Install Dependencies
         working-directory: ${{env.working-directory}}
         run: npm ci
@@ -32,6 +31,6 @@ jobs:
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish
         working-directory: ${{env.working-directory}}
-        run: npm publish --access public
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    env:
+      working-directory: js-library
 
     steps:
       - name: Checkout
@@ -17,14 +19,19 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm install -g npm
       - name: Install Dependencies
+        working-directory: ${{env.working-directory}}
         run: npm ci
       - name: Build
+        working-directory: ${{env.working-directory}}
         run: npm run build
       - name: Test
+        working-directory: ${{env.working-directory}}
         run: npm test
       - name: Set up npm
+        working-directory: ${{env.working-directory}}
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish
+        working-directory: ${{env.working-directory}}
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
# Motivation

Publish `@dfinty/verifiable-credentials` to NPM.

# Changes

* Add the Github workflow that will publish to NPM new releases created in Github.

# Tests

This is the same workflow used in ic-js, hardware-wallete-cli and generative-logo repository.