### PR TITLE
Manage Errors

### DIFF
--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -50,12 +50,6 @@ const createFlowId = (): FlowId => nanoid();
 
 type FlowId = string;
 const currentFlows = new Set<FlowId>();
-// Used to check race condition between
-// * Finishing handling a successful window message.
-// * Checking for closed window by user.
-// We don't want to call onError while we are managing a successful flow.
-
-const onGoingSuccessfulFlows = new Set<FlowId>();
 
 const INTERRUPT_CHECK_INTERVAL = 500;
 export const ERROR_USER_INTERRUPT = "UserInterrupt";

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -337,16 +337,16 @@ describe("Request Verifiable Credentials function", () => {
     const onError = vi.fn();
     const DURATION_BEFORE_USER_CLOSES_WINDOW = 1000;
     window.open = vi.fn().mockImplementation(() => {
-      const iiWindow = {
+      const idpWindow = {
         closed: false,
         close: vi.fn(),
       };
       // User closes the window after 1 second
       setTimeout(() => {
-        iiWindow.closed = true;
+        idpWindow.closed = true;
       }, DURATION_BEFORE_USER_CLOSES_WINDOW);
 
-      return iiWindow;
+      return idpWindow;
     });
     requestVerifiablePresentation({
       onSuccess: unreachableFn,
@@ -371,16 +371,16 @@ describe("Request Verifiable Credentials function", () => {
     const onError = vi.fn();
     const DURATION_BEFORE_USER_CLOSES_WINDOW = 1000;
     window.open = vi.fn().mockImplementation(() => {
-      const iiWindow = {
+      const idpWindow = {
         closed: false,
         close: vi.fn(),
       };
       // User closes the window after 1 second
       setTimeout(() => {
-        iiWindow.closed = true;
+        idpWindow.closed = true;
       }, DURATION_BEFORE_USER_CLOSES_WINDOW);
 
-      return iiWindow;
+      return idpWindow;
     });
     requestVerifiablePresentation({
       onSuccess: unreachableFn,
@@ -399,16 +399,22 @@ describe("Request Verifiable Credentials function", () => {
     expect(onError).toHaveBeenCalledWith(ERROR_USER_INTERRUPT);
   });
 
+  // Identity Provider closes the window after sending the response.
+  // We are checking in an interval whether the user closed the window.
+  // Setting the status to "finalized" to avoid calling `onError` in `checkInterruption` while we are dealing with the response.
+  // To check this in the test, I wrapped the `onSuccess` call inside a setTimeout to simulate that handling took long
+  // and force the `checkValidation` to see that the window was closed.
+  // Then I advanced the time in the test and checked that `onSuccess` was called, and not `onError`.
   it("should not call onError when window closes after successful flow", async () => {
     const onSuccess = vi.fn();
     const onError = vi.fn();
-    const iiWindow = {
+    const idpWindow = {
       closed: false,
       close() {
         this.closed = true;
       },
     };
-    window.open = vi.fn().mockReturnValue(iiWindow);
+    window.open = vi.fn().mockReturnValue(idpWindow);
     requestVerifiablePresentation({
       onSuccess,
       onError,


### PR DESCRIPTION
# Motivation

Improve how the library manages errors and exposes them to users.

The main improvement is to differentiate technical erros, which will output at onError, from not getting a credential for other reasons, which go to onSuccess with a different outout.

# Changes

* Change onSuccess param type.
* Check whether user closes the window without finishing flow. We consider this as a technical error and ends up in `onError`.
* Changed `currentFlows` from a `Set` to a `Map` with the status of the current flow. Then the status is changed and checked during the flow.

# Tests

* Remove skipped test `"calls onError with timeout error if flow doesn't start in five seconds"`. AuthClient doesn't manage it; therefore, I think that it makes sense we don't do it either.
* Implement test `"calls onError if user closes identity provider window"`.
* Add a test `"should not call onError when window closes after successful flow"`.
* Change the test `"calls onError when the credential fails"` to check that it calls `onSuccess`.
