### PR TITLE
Improve parameters types and docs

### DIFF
--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@dfinity/principal": "^1.3.0",
         "nanoid": "^5.0.7"
       },
       "devDependencies": {
@@ -144,6 +145,14 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@dfinity/principal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
+      "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
+      "dependencies": {
+        "@noble/hashes": "^1.3.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -693,6 +702,17 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
       "dev": true
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -70,6 +70,7 @@
     "vitest": "^1.5.0"
   },
   "dependencies": {
+    "@dfinity/principal": "^1.3.0",
     "nanoid": "^5.0.7"
   }
 }

--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -1,3 +1,11 @@
+/**
+ * This module provides a function to request a verifiable presentation to an issuer through the Identity Provider.
+ *
+ * More info about the flow: https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md
+ *
+ * There is only one function exposed: `requestVerifiablePresentation`.
+ */
+import type { Principal } from "@dfinity/principal";
 import { nanoid } from "nanoid";
 
 /**
@@ -14,11 +22,11 @@ export type CredentialRequestSpec = {
 };
 export type CredentialRequestData = {
   credentialSpec: CredentialRequestSpec;
-  credentialSubject: string;
+  credentialSubject: Principal;
 };
 export type IssuerData = {
   origin: string;
-  canisterId?: string;
+  canisterId?: Principal;
 };
 const VC_REQUEST_METHOD = "request_credential";
 const VC_START_METHOD = "vc-flow-ready";
@@ -28,7 +36,10 @@ export type CredentialsRequest = {
   jsonrpc: typeof JSON_RPC_VERSION;
   method: typeof VC_REQUEST_METHOD;
   params: {
-    issuer: IssuerData;
+    issuer: {
+      origin: string;
+      canisterId?: string;
+    };
     credentialSpec: CredentialRequestSpec;
     credentialSubject: string;
     derivationOrigin: string | undefined;
@@ -82,9 +93,12 @@ const createCredentialRequest = ({
     jsonrpc: JSON_RPC_VERSION,
     method: VC_REQUEST_METHOD,
     params: {
-      issuer: issuerData,
+      issuer: {
+        origin: issuerData.origin,
+        canisterId: issuerData.canisterId?.toText(),
+      },
       credentialSpec,
-      credentialSubject,
+      credentialSubject: credentialSubject.toText(),
       derivationOrigin: derivationOrigin,
     },
   };
@@ -130,6 +144,25 @@ const isKnownFlowMessage = ({
 }): boolean =>
   currentFlows.get(evnt.data?.id) === "ongoing" && evnt.data?.id === flowId;
 
+/**
+ * Function to request a verifiable presentation to an issuer through the Identity Provider.
+ *
+ * This function starts the connection with the Identity Provider through window post messages and handles the flow of the verifiable credential.
+ *
+ * @param {object} params
+ * @param {function} params.onSuccess - Callback function that is called when the flow with the Identity Provider is successful.
+ * It receives either the verifiable presentation or an message that the credential was not received.
+ * The message doesn't expose different errors to keep the privacy of the user.
+ * @param {function} params.onError - Callback function that is called when the flow has some technical error or the user closes the window.
+ * @param {CredentialRequestData} params.credentialData - Data to request the verifiable credential.
+ * @param {IssuerData} params.issuerData - Data of the issuer.
+ * @param {string} params.windowOpenerFeatures - Features of the window that opens the Identity Provider.
+ * @param {string} params.derivationOrigin - Indicates an origina that should be used for principal derivation.
+ * It's the same value as the one used when logging in.
+ * More info: https://internetcomputer.org/docs/current/references/ii-spec/#alternative-frontend-origins
+ * @param {string} params.identityProvider - URL of the Identity Provider.
+ * @returns {void}
+ */
 export const requestVerifiablePresentation = ({
   onSuccess,
   onError,
@@ -148,7 +181,7 @@ export const requestVerifiablePresentation = ({
   windowOpenerFeatures?: string;
   derivationOrigin: string | undefined;
   identityProvider: string;
-}) => {
+}): void => {
   const handleFlowFactory = (currentFlowId: FlowId) => (evnt: MessageEvent) => {
     // The handler is listening to all window messages.
     // For example, a browser extension could send messages that we want to ignore.
@@ -206,7 +239,13 @@ export const requestVerifiablePresentation = ({
   currentFlows.set(nextFlowId, "initialized");
   const handleCurrentFlow = handleFlowFactory(nextFlowId);
   window.addEventListener("message", handleCurrentFlow);
-  const url = new URL(identityProvider);
+  let url;
+  try {
+    url = new URL(identityProvider);
+  } catch (err) {
+    onError("The parameter `identityProvider` must be a valid URL.");
+    return;
+  }
   url.pathname = "vc-flow/";
   // As defined in the spec: https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md#1-load-ii-in-a-new-window
   const idpWindow = window.open(url, "idpWindow", windowOpenerFeatures);

--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -1,5 +1,5 @@
 /**
- * This module provides a function to request a verifiable presentation to an issuer through the Identity Provider.
+ * This module provides a function to request a verifiable presentation to an issuer through an Identity Provider.
  *
  * More info about the flow: https://github.com/dfinity/internet-identity/blob/main/docs/vc-spec.md
  *
@@ -52,6 +52,10 @@ type VerifiablePresentation = string;
 export type VerifiablePresentationResponse =
   | { Ok: VerifiablePresentation }
   | { Err: string };
+export type OnSuccessCallback = (
+  verifiablePresentation: VerifiablePresentationResponse,
+) => void | Promise<void>;
+export type OnErrorCallback = (err?: string) => void | Promise<void>;
 
 /**
  * Helper functions
@@ -144,20 +148,36 @@ const isKnownFlowMessage = ({
 }): boolean =>
   currentFlows.get(evnt.data?.id) === "ongoing" && evnt.data?.id === flowId;
 
+export type RequestVerifiablePresentationParams = {
+  onSuccess: OnSuccessCallback;
+  onError: (err?: string) => void | Promise<void>;
+  credentialData: CredentialRequestData;
+  issuerData: IssuerData;
+  windowOpenerFeatures?: string;
+  derivationOrigin: string | undefined;
+  identityProvider: string;
+};
+
 /**
- * Function to request a verifiable presentation to an issuer through the Identity Provider.
+ * Function to request a verifiable presentation to an issuer through an Identity Provider.
  *
- * This function starts the connection with the Identity Provider through window post messages and handles the flow of the verifiable credential.
+ * Summary of the flow:
+ * - The function opens a new window or tab with the Identity Provider.
+ * - Waits for a window post message from the Identity Provider.
+ * - Sends a request to the Identity Provider through the window post message.
+ * - Waits for the response from the Identity Provider.
+ * - Calls the `onSuccess` callback when the flow was successful. Not necessarily that the credential was received.
+ * - Calls the `onError` callback when the flow has some technical error or the user closes the window.
  *
- * @param {object} params
- * @param {function} params.onSuccess - Callback function that is called when the flow with the Identity Provider is successful.
+ * @param {RequestVerifiablePresentationParams} params
+ * @param {OnSuccessCallback} params.onSuccess - Callback function that is called when the flow with the Identity Provider is successful.
  * It receives either the verifiable presentation or an message that the credential was not received.
  * The message doesn't expose different errors to keep the privacy of the user.
- * @param {function} params.onError - Callback function that is called when the flow has some technical error or the user closes the window.
+ * @param {OnErrorCallback} params.onError - Callback function that is called when the flow has some technical error or the user closes the window.
  * @param {CredentialRequestData} params.credentialData - Data to request the verifiable credential.
  * @param {IssuerData} params.issuerData - Data of the issuer.
  * @param {string} params.windowOpenerFeatures - Features of the window that opens the Identity Provider.
- * @param {string} params.derivationOrigin - Indicates an origina that should be used for principal derivation.
+ * @param {string} params.derivationOrigin - Indicates an origin that should be used for principal derivation.
  * It's the same value as the one used when logging in.
  * More info: https://internetcomputer.org/docs/current/references/ii-spec/#alternative-frontend-origins
  * @param {string} params.identityProvider - URL of the Identity Provider.
@@ -171,17 +191,7 @@ export const requestVerifiablePresentation = ({
   windowOpenerFeatures,
   derivationOrigin,
   identityProvider,
-}: {
-  onSuccess: (
-    verifiablePresentation: VerifiablePresentationResponse,
-  ) => void | Promise<void>;
-  onError: (err?: string) => void | Promise<void>;
-  credentialData: CredentialRequestData;
-  issuerData: IssuerData;
-  windowOpenerFeatures?: string;
-  derivationOrigin: string | undefined;
-  identityProvider: string;
-}): void => {
+}: RequestVerifiablePresentationParams): void => {
   const handleFlowFactory = (currentFlowId: FlowId) => (evnt: MessageEvent) => {
     // The handler is listening to all window messages.
     // For example, a browser extension could send messages that we want to ignore.

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -1,3 +1,4 @@
+import { Principal } from "@dfinity/principal";
 import { vi } from "vitest";
 import {
   ERROR_USER_INTERRUPT,
@@ -8,8 +9,9 @@ import {
 import { credentialPresentationMock } from "./mocks";
 
 describe("Request Verifiable Credentials function", () => {
-  const credentialSubject =
-    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe";
+  const credentialSubject = Principal.fromText(
+    "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe",
+  );
   const identityProvider = "https://identity.ic0.app";
   const issuerOrigin = "https://jqajs-xiaaa-aaaad-aab5q-cai.ic0.app";
   const derivationOrigin = "https://metaissuer.vc/";
@@ -111,13 +113,19 @@ describe("Request Verifiable Credentials function", () => {
     expect(window.open).toHaveBeenCalledTimes(1);
   });
 
-  it("send expected request to the identity provider with derivationOrigin", async () => {
+  it("send expected request to the identity provider with derivationOrigin and issuer canisterId", async () => {
     const onSuccess = vi.fn();
+    const canisterId = Principal.fromText(
+      "2vtpp-r6lcd-cbfas-qbabv-wxrv5-lsrkj-c4dtb-6ets3-srlqe-xpuzf-vqe",
+    );
     requestVerifiablePresentation({
       onSuccess,
       onError: unreachableFn,
       credentialData,
-      issuerData,
+      issuerData: {
+        canisterId,
+        origin: issuerOrigin,
+      },
       derivationOrigin,
       identityProvider,
     });
@@ -133,9 +141,12 @@ describe("Request Verifiable Credentials function", () => {
       jsonrpc: "2.0",
       method: "request_credential",
       params: {
-        issuer: issuerData,
+        issuer: {
+          canisterId: canisterId.toText(),
+          origin: issuerOrigin,
+        },
         credentialSpec: credentialData.credentialSpec,
-        credentialSubject,
+        credentialSubject: credentialSubject.toText(),
         derivationOrigin,
       },
     });

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -367,6 +367,23 @@ describe("Request Verifiable Credentials function", () => {
     expect(onError).toHaveBeenCalledWith(ERROR_USER_INTERRUPT);
   });
 
+  it("calls onError if `identityProvider is not a valid URL`", async () => {
+    const onError = vi.fn();
+    requestVerifiablePresentation({
+      onSuccess: unreachableFn,
+      onError,
+      credentialData,
+      issuerData,
+      derivationOrigin: undefined,
+      identityProvider: "invalid-url",
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      "The parameter `identityProvider` must be a valid URL.",
+    );
+  });
+
   it("calls onError if user closes identity provider window even before the flow starts", async () => {
     const onError = vi.fn();
     const DURATION_BEFORE_USER_CLOSES_WINDOW = 1000;


### PR DESCRIPTION
# Motivation

Improve the documentation and validation of the parameters expected by `requestVerifiablePresentation`.

# Changes

* Wrap `new URL` with a try/catch to provide better feedback tot he user.
* Change types `string` for `Principal` for the credential subject and the issuer canister id.
* Add types for better documentation and developer experience.
* Add ts-doc comments and file comment.

# Tests

* Test that onError is called when `identityProvider` is not a valid URL.
* Change params type in tests.
* Add `canisterId` to the expected request sent to IdentityProvider through window post message.