### PR TITLE
Add @dfinity/principal as peer dependency

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ Changes in the upcoming versions.
 - Change the type of `CredentialData.credentialSubject` to `Principal`.
 - Change the type of `IssuerData.canisterId` to `Principal`.
 
+## Installation
+
+- List `@dfinity/principal` as a peer dependency.
+
 # 2024.05.03
 
 Release of the NPM library `@dfinity/verifiable-credentials`.

--- a/js-library/README.md
+++ b/js-library/README.md
@@ -12,6 +12,12 @@ Install library
 npm install @dfinity/verifiable-credentials
 ```
 
+The bundle needs peer dependencies, be sure that following resources are available in your project as well.
+
+```bash
+npm install @dfinity/principal
+```
+
 Import per modules:
 
 ```javascript

--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/principal": "^1.3.0",
         "nanoid": "^5.0.7"
       },
       "devDependencies": {
@@ -29,6 +28,9 @@
       },
       "engines": {
         "node": ">=v20.11.1"
+      },
+      "peerDependencies": {
+        "@dfinity/principal": "^1.3.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -152,6 +154,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
       "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
       }
@@ -708,6 +711,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -72,7 +72,9 @@
     "vitest": "^1.5.0"
   },
   "dependencies": {
-    "@dfinity/principal": "^1.3.0",
     "nanoid": "^5.0.7"
+  },
+  "peerDependencies": {
+    "@dfinity/principal": "^1.3.0"
   }
 }


### PR DESCRIPTION
# Motivation

The library expects some parameters as `Principal` now. Therefore, it makes sense to add them as peerDependency so that users of the library also install them.

# Changes

* Move `@dfinity/principal` to `peerDepedency`.
* Add the peer dependency installation in the readme.

# Tests

No new functionality.

# Todos

- [x] Add entry to changelog (if necessary).
