### PR TITLE
Prepare for DX improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,11 @@ Changes in the upcoming versions.
 ## Breaking Changes
 
 - Change the type of `CredentialData.credentialSubject` to `Principal`.
-- Change the type of `IssuerData.canisterId` to `Principal`.
+- Change the type of `IssuerData.canisterId` to `Principal` and make it mandatory.
+
+## Non-breaking Changes
+
+- `derivationOrigin` field is now optional.
 
 ## Installation
 

--- a/js-library/src/request-verifiable-presentation.ts
+++ b/js-library/src/request-verifiable-presentation.ts
@@ -26,7 +26,7 @@ export type CredentialRequestData = {
 };
 export type IssuerData = {
   origin: string;
-  canisterId?: Principal;
+  canisterId: Principal;
 };
 const VC_REQUEST_METHOD = "request_credential";
 const VC_START_METHOD = "vc-flow-ready";
@@ -38,11 +38,11 @@ export type CredentialsRequest = {
   params: {
     issuer: {
       origin: string;
-      canisterId?: string;
+      canisterId: string;
     };
     credentialSpec: CredentialRequestSpec;
     credentialSubject: string;
-    derivationOrigin: string | undefined;
+    derivationOrigin?: string;
   };
 };
 /**
@@ -154,7 +154,7 @@ export type RequestVerifiablePresentationParams = {
   credentialData: CredentialRequestData;
   issuerData: IssuerData;
   windowOpenerFeatures?: string;
-  derivationOrigin: string | undefined;
+  derivationOrigin?: string;
   identityProvider: string;
 };
 

--- a/js-library/src/tests/request-verifiable-presentation.spec.ts
+++ b/js-library/src/tests/request-verifiable-presentation.spec.ts
@@ -17,6 +17,7 @@ describe("Request Verifiable Credentials function", () => {
   const derivationOrigin = "https://metaissuer.vc/";
   const issuerData = {
     origin: issuerOrigin,
+    canisterId: Principal.fromText("2222s-4iaaa-aaaaf-ax2uq-cai"),
   };
   // Source: https://github.com/dfinity/internet-identity/blob/6df217532c7e3d4d465decbd9159ceab5262ba2d/src/vc-api/src/index.ts#L9
   const VcFlowReady = {
@@ -99,7 +100,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
 
@@ -160,7 +160,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
     const {
@@ -179,7 +178,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
     const {
@@ -201,7 +199,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
     mockMessageFromIdentityProvider({
@@ -223,7 +220,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
     const {
@@ -243,7 +239,6 @@ describe("Request Verifiable Credentials function", () => {
       onError,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
     const {
@@ -271,7 +266,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
     const {
@@ -283,7 +277,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
     const {
@@ -310,7 +303,6 @@ describe("Request Verifiable Credentials function", () => {
       onError: unreachableFn,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
 
@@ -364,7 +356,6 @@ describe("Request Verifiable Credentials function", () => {
       onError,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
 
@@ -385,7 +376,6 @@ describe("Request Verifiable Credentials function", () => {
       onError,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider: "invalid-url",
     });
 
@@ -415,7 +405,6 @@ describe("Request Verifiable Credentials function", () => {
       onError,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
 
@@ -448,7 +437,6 @@ describe("Request Verifiable Credentials function", () => {
       onError,
       credentialData,
       issuerData,
-      derivationOrigin: undefined,
       identityProvider,
     });
 


### PR DESCRIPTION
# Motivation

Prepare the SDK for the improvements in developer experience discussed offline:

* `Issuer.canisterId` is mandatory.
* `derivationOrigin` should be avoided.

# Changes

* Make `Issuer.canisterId` as mandatory.
* Make `derivationOrigin` optional.

# Tests

Remove the `derivationOrigin: undefined` from the tests and add the canisterId in the shared issuer data.

# Todos

- [x] Add entry to changelog (if necessary).
