### PR TITLE
Set identityProvider as URL type

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Changes in the upcoming versions.
 
 - Change the type of `CredentialData.credentialSubject` to `Principal`.
 - Change the type of `IssuerData.canisterId` to `Principal` and make it mandatory.
+- Change the type of `identityProvider` to `URL`.
 
 ## Non-breaking Changes
 


### PR DESCRIPTION
# Motivation

I was having issues sometimes with the VC flow getting stuck.

The problem was that the identity provider I was setting in the RP had a trailing slash, while the origin of the event didn't. Therefore, the comparison of whether the message came from the expected source failed and the library never sent the credential request.

# Changes

* Set the type of `identityProvider` as `URL` as well as converting the `event.origin` to `URL` before comparing them both.

# Tests

* Remove a test with an invalid `identityProvider` URL and add a test with a URL with a trailing slash.

# Todos

- [ ] Add entry to changelog (if necessary).
