### PR TITLE
New Release of NPM package

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Upcoming
 
+## Breaking Changes
+
+# 2024.06.10
+
 Changes in the upcoming versions.
 
 ## New projects

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/verifiable-credentials",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Library to interact with the identity provider to get a credential presentation.",
   "type": "module",
   "files": [


### PR DESCRIPTION
# Motivation

We discovered a bug in the JS library when the origins didn't match due to trailing slashes.

We fixed it by changing the type of the URL from `string` to `URL`.

I'd like to publish the fix before we publish the docs.

# Changes

* Change package.json version to 0.0.2.
* Update CHANGELOG.

# Todos

- [x] Add entry to changelog (if necessary).
