### PR TITLE
Dummy Relying Party: Remove error after successful credential

### DIFF
--- a/dummy-relying-party/frontend/src/main.ts
+++ b/dummy-relying-party/frontend/src/main.ts
@@ -239,6 +239,9 @@ const renderDecodedCredentialPresentation = (jwt: string) => {
 
 const renderCredential = (jwt: string) => {
   showVcContainer();
+  if (credentialErrorElement) {
+    credentialErrorElement.innerText = "";
+  }
   if (vcResultElement && vcContainer) {
     vcResultElement.innerText = jwt;
     window.scrollTo({ top: vcContainer.offsetTop, behavior: "smooth" });


### PR DESCRIPTION
# Motivation

The error message of requesting credentials was present after receiving a successful credential.

This is because the error container wasn't cleaned. This is why the mindset State -> UI is better than pure dom manipulation 😂 

# Changes

* Clean up the error container when successfule credential is rendered.

# Tests

Tested manually.

# Todos

- [ ] Add entry to changelog (if necessary). NOT NECESSARY
