### PR TITLE
Add rust cache to CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: cargo-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          restore-keys: cargo-
       - name: Install dependencies
         working-directory: dummy-e2e
         run: npm ci

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,11 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            ~/.cargo
+            target
+          key: cargo-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          restore-keys: cargo-
 
       - name: Install Rust
         run: |
           rustup component add rustfmt
           rustup component add clippy
+          cargo --version
 
       - name: Check Format
         run: cargo fmt --all -- --check


### PR DESCRIPTION
# Motivation

This PR adds caching to the Cargo Test and Playwright workflows, which should improve its speed quite a bit.

Further changes should be made to CI to only build artifacts once. Currently each workflow builds their own. However, that will be done in separate PRs.

