### PR TITLE
Do not publish to npm if no changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
         run: printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' registry=https://registry.npmjs.org/ always-auth=true >> .npmrc
       - name: Publish
         working-directory: ${{env.working-directory}}
-        run: npm publish --provenance --access public
+        run: ./scripts/publish-npm.sh
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # NPM libraries
 node_modules
 dist
+# Output of 'npm pack'
+*.tgz
 
 # Editor settings
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add canister id input in the dummy relying party.
 - Upgrade `@dfinity/verifiable-credentials` used in the dummy relying party to the latest published version.
 - Port vc-util from II to this repository and rename it to `ic-verifiable-credentials`.
+- Do not publish to NPM the JS library if there were no changes.
 
 # 2024.06.10
 

--- a/js-library/scripts/publish-npm.sh
+++ b/js-library/scripts/publish-npm.sh
@@ -2,7 +2,7 @@
 
 # Reference: NPM RRFC --if-needed https://github.com/npm/rfcs/issues/466
 
-LOCAL_SHASUM=$(npm pack --json | jq '.[] | .shasum' | sed -r 's/^"|"$//g')
+LOCAL_SHASUM=$(npm --silent pack --json | jq '.[] | .shasum' | sed -r 's/^"|"$//g')
 
 NPM_TARBALL=$(npm show @dfinity/verifiable-credentials dist.tarball)
 NPM_SHASUM=$(curl -s "$NPM_TARBALL" 2>&1 | shasum | cut -f1 -d' ')

--- a/js-library/scripts/publish-npm.sh
+++ b/js-library/scripts/publish-npm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Reference: NPM RRFC --if-needed https://github.com/npm/rfcs/issues/466
+
+LOCAL_SHASUM=$(npm pack --json | jq '.[] | .shasum' | sed -r 's/^"|"$//g')
+
+NPM_TARBALL=$(npm show @dfinity/verifiable-credentials dist.tarball)
+NPM_SHASUM=$(curl -s "$NPM_TARBALL" 2>&1 | shasum | cut -f1 -d' ')
+
+if [ "$LOCAL_SHASUM" == "$NPM_SHASUM" ]; then
+  echo "No changes in @dfinity/verifiable-credentials need to be published to NPM."
+else
+  npm publish --provenance --access public
+fi


### PR DESCRIPTION
# Motivation

Avod publishing `@dfinity/verifiable-credentials` if there were no changes in the library.

# Changes

* New script `publish-npm.sh`.
* Use the new script in workflow publish.
* Add npm pack tarball extension to gitignore.

# Tests

Tested manually.

# Todos

- [x] Add entry to changelog (if necessary).
