### PR TITLE
build: ignore mocks

### DIFF
--- a/js-library/esbuild.mjs
+++ b/js-library/esbuild.mjs
@@ -32,6 +32,7 @@ const bundleFiles = () => {
       (file) =>
         !file.includes("test") &&
         !file.includes("spec") &&
+        !file.includes("mock") &&
         statSync(join(process.cwd(), "src", file)).isFile(),
     )
     .map((file) => `src/${file}`);


### PR DESCRIPTION
# Motivation

In addition to test fiels, it's probably good to also skip mocks in the build.

