### PR TITLE
build: agent-js peer dependency v2

### DIFF
--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -30,7 +30,7 @@
         "node": ">=v20.11.1"
       },
       "peerDependencies": {
-        "@dfinity/principal": "^1.3.0"
+        "@dfinity/principal": "^2.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -151,9 +151,10 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-1.3.0.tgz",
-      "integrity": "sha512-04Ly9/VxztgmSk3LeUv1H+aA/8zCfed5gzgydVKBv9U0pk2lcCjUOMhv3G+1UCUSd8GwzrWaSwIsrzrAcHZm/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.0.0.tgz",
+      "integrity": "sha512-cqJ5kOrPpxco+wvJC4TFBhdr4lkw9mnwKGAYunesyqdzSYi8lnFB4dShNqlHFWdwoxNAw6OZkt/B+0nLa+7Yqw==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@noble/hashes": "^1.3.1"
@@ -711,6 +712,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 16"

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -75,6 +75,6 @@
     "nanoid": "^5.0.7"
   },
   "peerDependencies": {
-    "@dfinity/principal": "^1.3.0"
+    "@dfinity/principal": "^2.0.0"
   }
 }


### PR DESCRIPTION
# Motivation

If we bump agent-js in ic-js in our dapps, we also need to bump it in the `verifiable-credentials`.
