### PR TITLE
Fix bug in canister sig public key handling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,5 +51,8 @@ jobs:
         working-directory: dummy-issuer
         run: ./build.sh
 
+      - name: Create dist folder
+        run: mkdir -p dummy-relying-party/frontend/dist
+
       - name: Cargo tests
         run: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,8 +51,5 @@ jobs:
         working-directory: dummy-issuer
         run: ./build.sh
 
-      # fails if lockfile is out of date
-      # https://users.rust-lang.org/t/check-if-the-cargo-lock-is-up-to-date-without-building-anything/91048/5
-      # Run only dummy_issuer to avoid building dummy_relying_party
       - name: Cargo tests
-        run: cargo test --package dummy_issuer
+        run: cargo test

--- a/rust-packages/ic-verifiable-credentials/src/lib.rs
+++ b/rust-packages/ic-verifiable-credentials/src/lib.rs
@@ -635,7 +635,7 @@ pub fn get_canister_sig_pk_raw(
 }
 
 /// Extracts and returns the DER encoded canister sig public key from the given header.
-fn get_canister_sig_pk_der(jws_header: &JwsHeader) -> Result<Vec<u8>, SignatureVerificationError> {
+pub fn get_canister_sig_pk_der(jws_header: &JwsHeader) -> Result<Vec<u8>, SignatureVerificationError> {
     let jwk = jws_header
         .deref()
         .jwk()

--- a/rust-packages/ic-verifiable-credentials/src/lib.rs
+++ b/rust-packages/ic-verifiable-credentials/src/lib.rs
@@ -635,7 +635,9 @@ pub fn get_canister_sig_pk_raw(
 }
 
 /// Extracts and returns the DER encoded canister sig public key from the given header.
-pub fn get_canister_sig_pk_der(jws_header: &JwsHeader) -> Result<Vec<u8>, SignatureVerificationError> {
+pub fn get_canister_sig_pk_der(
+    jws_header: &JwsHeader,
+) -> Result<Vec<u8>, SignatureVerificationError> {
     let jwk = jws_header
         .deref()
         .jwk()


### PR DESCRIPTION
The last PR (#49) unfortunately introduced a bug (confusion between DER encoded and raw canister signature public key). This PR fixes it.

In addition, #49 could only be merged, because the unit test for the rust library were not actually run. CI is changed to no run all rust tests.

