### PR TITLE
Fix nextJS issue

### DIFF
--- a/js-library/README.md
+++ b/js-library/README.md
@@ -18,11 +18,16 @@ The bundle needs peer dependencies, be sure that following resources are availab
 npm install @dfinity/principal
 ```
 
-Import per modules:
+Import per modules to have small app size:
 
 ```javascript
-// import * from '@dfinity/verifiable-credentials'; // Error: use sub-imports, to ensure small app size
 import { requestVerifiablePresentation } from "@dfinity/verifiable-credentials/request-verifiable-presentation";
+```
+
+Or import default:
+
+```javascript
+import { requestVerifiablePresentation } from "@dfinity/verifiable-credentials";
 ```
 
 ## Relying Party: Request Credentials

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -56,6 +56,8 @@
       "types": "./dist/request-verifiable-presentation.d.ts"
     }
   },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.7",

--- a/js-library/src/index.ts
+++ b/js-library/src/index.ts
@@ -1,3 +1,1 @@
-throw new Error(
-  "verifiable-credentials have no entry-point: consult README for usage",
-);
+export * from "./request-verifiable-presentation";


### PR DESCRIPTION
# Motivation

There is an issue with the JS library when the moduleResolution is set to `node` which happens in NextJS projects.

The issue was raised here: https://github.com/dfinity/verifiable-credentials-sdk/issues/48

# Changes

* Support importing from 

# Tests

Tested that dummy-relying-party still builds with the changes.

# Todos

- [ ] Add entry to changelog (if necessary).
