### PR TITLE
fix: ci publish not finding script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,6 @@ jobs:
 
       - name: Publish
         working-directory: ${{env.dist-directory}}
-        run: ./scripts/publish-npm.sh
+        run: ../scripts/publish-npm.sh
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
# Motivation

Fix publish CI [issue](https://github.com/dfinity/verifiable-credentials-sdk/actions/runs/10789761112/job/29923443711)

# Changes

- The script `publish-npm.sh` find place in a parent folder now that we release from `dist`, so `../` instead of `./`
