### PR TITLE
chore: pack ts and js from subfolders

### DIFF
--- a/js-library/package.json
+++ b/js-library/package.json
@@ -6,10 +6,10 @@
   "files": [
     "README.md",
     "LICENSE",
-    "*.js",
-    "*.js.map",
-    "*.d.ts",
-    "*.d.ts.map"
+    "**/*.js",
+    "**/*.js.map",
+    "**/*.d.ts",
+    "**/*.d.ts.map"
   ],
   "engines": {
     "node": ">=v20.11.1"


### PR DESCRIPTION
# Motivation

It's currently NOT an issue for this library but, in the Oisy Signer JS lib I noticed that TS types might be generated in subfolders. That's why for future proof, it's better to also set the `package.json` to include potential subfolders when publishing.

# Changes

- Update `files` wildcard in `package.json`.
