### PR TITLE
Remap new domain to old domain in expected origin for id alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "identity_core",
  "identity_credential",
  "identity_jose",
+ "regex",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -2110,14 +2111,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2131,13 +2132,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -2148,9 +2149,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/rust-packages/ic-verifiable-credentials/Cargo.toml
+++ b/rust-packages/ic-verifiable-credentials/Cargo.toml
@@ -26,6 +26,7 @@ serde_cbor.workspace = true
 serde_json = "1"
 sha2.workspace = true
 base64.workspace = true
+regex = "1.11.1"
 
 [dev-dependencies]
 assert_matches = "1.5"


### PR DESCRIPTION
# Motivation

II uses the old domain `ic0.app` to derive the principals even when the dapp is hosted in the new domain `icp0.io`. This happens in the `remapToLegacyDomain` helper in II.

Therefore, the origin of the id alias credential uses the old domain `ic0.app` even though the dapp is hosted in the new domain `icp0.io`.

Instead of requiring the developers to understand and know about this implementation detail, we decided to map the new domain of the expected origin to the old domain before comparing them.

# Changes

* New helper `remap_to_legacy_domain`.
* Use new helper when comparing domains.

# Tests

* Add tests for the helper.
* Add a test where the expected origin uses the new domain.

# Todos

- [ ] Add entry to changelog (if necessary). NOT NECESSARY.
