### PR TITLE
Prepare release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Changes in the upcoming versions.
 
 ## Breaking Changes
 
-- New field `derivationOrigin` is required to match in the ID Alias credential.
+## Improvements
+
+# release-2024-10-29
+
+## Breaking Changes
+
+- New field `derivationOrigin` is required to match in the ID Alias credential in `ic-verifiable-credentials`.
 
 ## Improvements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "ic-verifiable-credentials"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.1"
+version = "1.0.0"
 authors = ["DFINITY Stiftung"]
 edition = "2024"
 repository = "https://github.com/dfinity/verifiable-credentials-sdk"

--- a/js-library/package-lock.json
+++ b/js-library/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/verifiable-credentials",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/verifiable-credentials",
-      "version": "0.0.4",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "^5.0.7"

--- a/js-library/package.json
+++ b/js-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/verifiable-credentials",
-  "version": "0.0.4",
+  "version": "1.0.0",
   "description": "Library to interact with the identity provider to get a credential presentation.",
   "type": "module",
   "files": [

--- a/rust-packages/ic-verifiable-credentials/Cargo.toml
+++ b/rust-packages/ic-verifiable-credentials/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ic-verifiable-credentials"
 description = "Verifiable credentials issuing and verification for IC canisters."
-version = "0.1.0"
+version = "1.0.0"
 keywords = ["internet-computer", "verifiable", "credentials", "icp", "dfinity"]
 categories = ["api-bindings", "data-structures", "no-std"]
 edition = "2021"


### PR DESCRIPTION
# Motivation

Release `ic-verifiable-credentials` to crates.io with v1.0.0 and bump the js-library to keep it consistent.

# Changes

## Manual Changes

* Bump to v1.0.0 in Cargo.toml and package.json files.
* Changelog

## Automatic changes

* Changes in Cargo.lock.
* Changes in package-lock.json in the js-library.

# Tests

Not necessary.

# Todos

- [x] Add entry to changelog (if necessary).
