### PR TITLE
Add license entry in package Cargo.toml

### DIFF
--- a/rust-packages/ic-verifiable-credentials/Cargo.toml
+++ b/rust-packages/ic-verifiable-credentials/Cargo.toml
@@ -5,6 +5,7 @@ version = "1.0.0"
 keywords = ["internet-computer", "verifiable", "credentials", "icp", "dfinity"]
 categories = ["api-bindings", "data-structures", "no-std"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 # ic dependencies


### PR DESCRIPTION
# Motivation

Publishing to crates.io failed because of missing license.

# Changes

* Add `license` entry in the package Cargo.toml

# Tests

* I tried the publishing command with `--dry-run` and all tests passed.

# Todos

- [ ] Add entry to changelog (if necessary). NOT NECESSARY.
