### PR TITLE
Add workflow to publish to crates.io

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,6 +1,9 @@
 name: Publish to crates.io
 
 on:
+  # Manual trigger
+  workflow_dispatch:
+
   release:
     types: [released]
 

--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,46 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry
+
+      - name: Cache Cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index
+          restore-keys: |
+            ${{ runner.os }}-cargo-index
+
+      - name: Build the project
+        run: cargo build --release
+
+      - name: Run tests
+        run: cargo test --release
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish


### PR DESCRIPTION
# Motivation

We want to publish `ic-verifiable-credentials` to crates.io.

# Changes

* Add a workflow to publish manually or when a new release is created.

# Tests

I hope to test it when the secret is added. I will then create a new release and the workflow will be triggered.

If it works, I will then do a PR to remove the manual trigger option. Otherwise, I will do a branch to try to fix it and trigger it manually.

# Todos

- [ ] Add entry to changelog (if necessary). NOT NECESSARY
