### PR TITLE
Disable publish-crate workflow

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   publish:
+    # Disable until CARGO_REGISTRY_TOKEN secret is available.
+    if: false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Motivation

Crates must be published from a personal account instead of with a CI (for now).

# Changes

* Disable the `publish-crate` workflow.

# Tests

Not tested because there is nothing to run.

# Todos

- [ ] Add entry to changelog (if necessary). NOT NECESSARY
