### PR TITLE
Add readme for `ic-verifiable-credentials` and bump library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,7 +1262,7 @@ dependencies = [
 
 [[package]]
 name = "ic-verifiable-credentials"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a set of libraries to manage verifiable credentials whe
 ## Libraries
 
 - [Javascript Library](./js-library/README.md). At the moment only a client for relying parties.
+- [ic-verifiable-credentials](./rust-packages/ic-verifiable-credentials/README.md). Verifiable credentials issuing and verification for IC canisters.
 
 ## Projects
 
@@ -18,7 +19,3 @@ There is a deployed version in Internet Computer here: [https://l7rua-raaaa-aaaa
 You can test it against the dummy issuer deployed in [canister id qdiif-2iaaa-aaaap-ahjaq-cai](https://dashboard.internetcomputer.org/canister/qdiif-2iaaa-aaaap-ahjaq-cai).
 
 You can use the staging Internet Identity: [https://fgte5-ciaaa-aaaad-aaatq-cai.ic0.app/](https://fgte5-ciaaa-aaaad-aaatq-cai.ic0.app/).
-
-## Upcoming
-
-- [ ] Library for relying parties to validate credentials.

--- a/rust-packages/ic-verifiable-credentials/Cargo.toml
+++ b/rust-packages/ic-verifiable-credentials/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ic-verifiable-credentials"
 description = "Verifiable credentials issuing and verification for IC canisters."
-version = "1.0.0"
+version = "1.0.1"
 keywords = ["internet-computer", "verifiable", "credentials", "icp", "dfinity"]
 categories = ["api-bindings", "data-structures", "no-std"]
 edition = "2021"

--- a/rust-packages/ic-verifiable-credentials/README.md
+++ b/rust-packages/ic-verifiable-credentials/README.md
@@ -1,0 +1,46 @@
+# ic-verifiable-credentials
+
+## About
+
+Verifiable credentials issuing and verification for IC canisters.
+
+Issuers can use this library to issue credentials and verify the id alias credential received from the identity provider.
+
+Relying parties can use this library to verify the credentials received.
+
+More information about [Verifiable Credentials in the Internet Computer documentation](https://internetcomputer.org/docs/current/developer-docs/identity/verifiable-credentials/overview).
+
+## Getting Started
+
+### Installation
+
+Install with cargo:
+
+```shell
+cargo add ic-verifiable-credentials
+```
+
+Or add it to your `Cargo.toml`.
+
+```toml
+ic-verifiable-credentials = "1.0.0"
+```
+
+### Usage
+
+Main functions for issuers:
+
+- `build_credential_jwt`. Builds a verifiable credential with the given parameters and returns the credential as a JWT-string.
+- `did_for_principal`. Returns a DID for the given `principal`.
+- `vc_jwt_to_jws`. Constructs and returns a JWS (a signed JWT) from the given components.
+- `vc_signing_input`. Returns the effective bytes that will be signed when computing a canister signature for the given JWT-credential, verifiable via the specified public key.
+- `vc_signing_input_hash`. Computes and returns SHA-256 hash of the given `signing_input`.
+- `get_verified_id_alias_from_jws`. Verifies the given JWS-credential as an id_alias-VC and extracts the alias tuple.
+
+Main function for relying parties:
+
+- `validate_ii_presentation_and_claims`. Validates the provided presentation `vp_jwt`, both cryptographically and semantically.
+
+## License
+
+Distributed under the Apache License. See [LICENSE](https://github.com/dfinity/verifiable-credentials-sdk/blob/main/LICENSE) for more information.


### PR DESCRIPTION
# Motivation

The library is published in crates.io but there is no readme for developers to understand what this library is about.

# Changes

* Edit main README to introduce the new library.
* Add new README for `ic-verifiable-credentials` which will be fetched by crates.io.

# Tests

Only doc changes.

# Todos

- [ ] Add entry to changelog (if necessary). NOT necessary.
