### PR TITLE
chore: fix set next version

### DIFF
--- a/js-library/scripts/update-version.mjs
+++ b/js-library/scripts/update-version.mjs
@@ -26,7 +26,7 @@ const nextVersion = async ({ project, currentVersion }) => {
 };
 
 const updateVersion = async () => {
-  const packagePath = join(process.cwd(), "package.json");
+  const packagePath = join(process.cwd(), "dist", "package.json");
 
   if (!existsSync(packagePath)) {
     console.log(`Target ${packagePath} does not exist.`);


### PR DESCRIPTION
# Motivation

The `update-version.mjs` script currently updates the `version` field in `js-library/package.json`, which is the package json that defines  the library.

However, the CI pipeline builds and prepares the library for release **before** this version update occurs. As a result, the `version` field in the published package is not updated, since it reflects the version from before the script ran.

This happens because the `dist/package.json` — the one that actually gets published with the library — is generated during the build step and does **not** include the updated version.

# Changes

- Update the package json file within `dist` folder with `update-version.mjs`.
