### PR TITLE
fix: correct setup-rust-toolchain action reference

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Rust toolchain
-        uses: rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.88.0
 


### PR DESCRIPTION
## Summary
- Fix `publish-rust` job in publish workflow: the `setup-rust-toolchain` action is under the `actions-rust-lang` org, not `rust-lang`
- This was causing the crates.io publish to fail with "Unable to resolve action rust-lang/setup-rust-toolchain, repository not found"

## Test plan
- [ ] Merge and re-trigger the `release-2026-03-06` publish workflow to publish `ic-verifiable-credentials@1.3.0` to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)