### PR TITLE
chore: update crate version in README to 1.3.0

### DIFF
--- a/rust-packages/ic-verifiable-credentials/README.md
+++ b/rust-packages/ic-verifiable-credentials/README.md
@@ -23,7 +23,7 @@ cargo add ic-verifiable-credentials
 Or add it to your `Cargo.toml`.
 
 ```toml
-ic-verifiable-credentials = "1.0.0"
+ic-verifiable-credentials = "1.3.0"
 ```
 
 ### Usage


### PR DESCRIPTION
## Summary
- Update `ic-verifiable-credentials` version in README from `1.0.0` to `1.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)