### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install dependencies
         working-directory: ${{env.working-directory}}
         run: npm ci
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install dependencies
         working-directory: ${{env.working-directory}}
         run: npm ci
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install dependencies
         working-directory: ${{env.working-directory}}
         run: npm ci

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,11 +9,11 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache
         with:
           path: |
@@ -30,7 +30,7 @@ jobs:
         working-directory: dummy-e2e
         run: npx playwright install --with-deps
       - name: Install dfx
-        uses: dfinity/setup-dfx@main
+        uses: dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main
       - name: Start local replica
         run: dfx start --background
       - name: Deploy canisters
@@ -41,7 +41,7 @@ jobs:
       - name: Run Playwright tests
         working-directory: dummy-e2e
         run: npm run e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Prepare and Build JS Library
         uses: ./.github/actions/prepare
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare and Build JS Library
         uses: ./.github/actions/prepare
@@ -75,10 +75,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
         with:
           toolchain: 1.88.0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache
         with:
           path: |
@@ -22,7 +22,7 @@ jobs:
       - name: Install ic-wasm
         run: cargo install ic-wasm --version 0.9.10
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: lts/*
 
@@ -33,7 +33,7 @@ jobs:
         run: ./dummy-relying-party/build.sh
 
       - name: Create Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: create-release
         with:
           result-encoding: string
@@ -51,7 +51,7 @@ jobs:
             return response.data.id;
 
       - name: Upload Issuer Wasm
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.repos.uploadReleaseAsset({
@@ -63,7 +63,7 @@ jobs:
             });
 
       - name: Upload Issuer Interface
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.repos.uploadReleaseAsset({
@@ -75,7 +75,7 @@ jobs:
             });
 
       - name: Upload Relying Party Wasm
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.repos.uploadReleaseAsset({
@@ -87,7 +87,7 @@ jobs:
             });
 
       - name: Upload Relying Party Interface
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             await github.rest.repos.uploadReleaseAsset({

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: cache
         with:
           path: |


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `actions/setup-node@v4` -> `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0`
  - Version: v4.4.0 | Latest: v6.3.0 | Release age: 37d
  - Commit: https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020

- `actions/cache@v4` -> `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0`
  - Version: v4.3.0 | Latest: v5.0.4 | Release age: 22d
  - Commit: https://github.com/actions/cache/commit/0057852bfaa89a56745cba8c7296529d2fc39830

- `dfinity/setup-dfx@main` -> `dfinity/setup-dfx@e50c04f104ee4285ec010f10609483cf41e4d365 # main`
  - Version: main | Latest: ? | Release age: ?
  - Commit: https://github.com/dfinity/setup-dfx/commit/e50c04f104ee4285ec010f10609483cf41e4d365

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 23d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02

- `actions/checkout@v5` -> `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1`
  - Version: v5.0.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/93cb6efe18208431cddfb8368fd83d5badbf9bfd

- `actions-rust-lang/setup-rust-toolchain@v1` -> `actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4`
  - Version: v1.15.4 | Latest: v1.15.4 | Release age: 26d
  - Commit: https://github.com/actions-rust-lang/setup-rust-toolchain/commit/150fca883cd4034361b621bd4e6a9d34e5143606

- `actions/github-script@v7` -> `actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0`
  - Version: v7.1.0 | Latest: v9.0.0 | Release age: 217d
  - Commit: https://github.com/actions/github-script/commit/f28e40c7f34bde8b3046d885e986cb6290c5673b
  - Warnings: Latest release v9.0.0 is only 0 day(s) old (< 7 days). Using previous safe release.


### Files modified

- `.github/workflows/checks.yml`
- `.github/workflows/playwright.yml`
- `.github/workflows/publish.yml`
- `.github/workflows/release.yml`
- `.github/workflows/rust.yml`

### Security warnings

- Latest release v9.0.0 is only 0 day(s) old (< 7 days). Using previous safe release.