### PR TITLE
chore: bump IC crates to latest versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.14"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d90f5a1426d0489283a0bd5da9ed406fb3e69597e0d823dcb88a1965bb58d2"
+checksum = "b649560badafa98cdf260958393f317c013b5aa819dba26f21cc3e26cae41dae"
 dependencies = [
  "anyhow",
  "binread",
@@ -239,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.6.6"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de398570c386726e7a59d9887b68763c481477f9a043fb998a2e09d428df1a9"
+checksum = "8f94f9df97dd04077b5a30e82dfb5a5f2eae1a6e8c9d6a98fd24351c8a333464"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -410,11 +410,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -424,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -524,9 +523,9 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "ic-canister-sig-creation",
- "ic-cdk 0.18.3",
- "ic-cdk-macros 0.18.3",
- "ic-certification 2.6.0",
+ "ic-cdk 0.20.2",
+ "ic-cdk-macros 0.20.2",
+ "ic-certification",
  "ic-crypto-getrandom-for-wasm",
  "ic-verifiable-credentials",
  "lazy_static",
@@ -544,8 +543,8 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "candid",
- "ic-cdk 0.18.3",
- "ic-cdk-macros 0.18.3",
+ "ic-cdk 0.20.2",
+ "ic-cdk-macros 0.20.2",
  "ic-http-certification",
  "include_dir",
  "lazy_static",
@@ -790,7 +789,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap",
  "slab",
  "tokio",
@@ -863,17 +862,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -890,7 +878,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -901,7 +889,7 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "pin-project-lite",
 ]
@@ -928,7 +916,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "httparse",
  "itoa",
@@ -945,7 +933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.1.0",
+ "http",
  "hyper",
  "hyper-util",
  "rustls",
@@ -966,7 +954,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body",
  "hyper",
  "pin-project-lite",
@@ -979,15 +967,15 @@ dependencies = [
 
 [[package]]
 name = "ic-canister-sig-creation"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4de4a335e8f13986a39e8d1c02aa6999c7aa5736bc0083dacafe3a99b26f3a2"
+checksum = "d8b2a507d1bebb111fc8c76098468e4de9c745e9b9ef160a079568ae1d6f7fef"
 dependencies = [
  "candid",
  "hex",
- "ic-cdk 0.18.3",
- "ic-certification 3.0.3",
- "ic-representation-independent-hash 3.0.3",
+ "ic-certification",
+ "ic-representation-independent-hash",
+ "ic0 1.1.0",
  "lazy_static",
  "serde",
  "serde_bytes",
@@ -1011,29 +999,29 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.18.3"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f23cb28bde80ae66f4d6c2bb8682ff6d0de1191666fe032995a21c021e52eb"
+checksum = "6a7971f4983db147afbbc4e7f87f60b09fcd60ac707af37ff3d2468dcddbf551"
 dependencies = [
  "candid",
  "ic-cdk-executor",
- "ic-cdk-macros 0.18.3",
+ "ic-cdk-macros 0.20.2",
  "ic-error-types",
- "ic-management-canister-types",
- "ic0 0.25.1",
+ "ic0 1.1.0",
+ "pin-project-lite",
  "serde",
- "serde_bytes",
- "slotmap",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "ic-cdk-executor"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3586c51b6b3809b69c79e97de172b4649f56094e8c8bc1ce2e41a29f20ed5f"
+checksum = "33716b730ded33690b8a704bff3533fda87d229e58046823647d28816e9bcee7"
 dependencies = [
+ "ic0 1.1.0",
  "slotmap",
+ "smallvec",
 ]
 
 [[package]]
@@ -1052,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.18.3"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8b6aa0b94984fdc67180acd28d608a19416722b69e439f53b40a4ba8133e6d"
+checksum = "a7c20c002200c720958f321bb78b4d4987fc2c380bf9ef69ed4404730810f45f"
 dependencies = [
  "candid",
  "darling",
@@ -1065,21 +1053,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "2.6.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64ee3d8b6e81b51f245716d3e0badb63c283c00f3c9fb5d5219afc30b5bf821"
-dependencies = [
- "hex",
- "serde",
- "serde_bytes",
- "sha2",
-]
-
-[[package]]
-name = "ic-certification"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb40d73f9f8273dc6569a68859003bbd467c9dc6d53c6fd7d174742f857209d"
+checksum = "754e3037360152de7e5f2bd0ccf51db8864b6a03c5a2b4ffc6a65286c0e2ffa7"
 dependencies = [
  "hex",
  "serde",
@@ -1108,45 +1084,26 @@ dependencies = [
 
 [[package]]
 name = "ic-http-certification"
-version = "2.6.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff0b97e949845039149dc5e7ea6a7c12ee4333bb402e37bc507904643c7b3e41"
+checksum = "689c75307307b577220b7bade846123d62ef0a8fe536540267571c8e94825cf5"
 dependencies = [
+ "base64 0.22.1",
  "candid",
- "http 0.2.12",
- "ic-certification 2.6.0",
- "ic-representation-independent-hash 2.6.0",
+ "http",
+ "ic-certification",
+ "ic-representation-independent-hash",
  "serde",
+ "serde_cbor",
  "thiserror 1.0.63",
  "urlencoding",
 ]
 
 [[package]]
-name = "ic-management-canister-types"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98554c2d8a30c00b6bfda18062fdcef21215cad07a52d8b8b1eb3130e51bfe71"
-dependencies = [
- "candid",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "ic-representation-independent-hash"
-version = "2.6.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ae59483e377cd9aad94ec339ed1d2583b0d5929cab989328dac2d853b2f570"
-dependencies = [
- "leb128",
- "sha2",
-]
-
-[[package]]
-name = "ic-representation-independent-hash"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2800ba4910f21d9e1cb7b6ecbbbb0f76074bd2e127b4688c57d0936206caa6e"
+checksum = "c80c46e399bcce51c531237e1111ced114dec295cff22b0996099a6168814b03"
 dependencies = [
  "leb128",
  "sha2",
@@ -1154,12 +1111,12 @@ dependencies = [
 
 [[package]]
 name = "ic-signature-verification"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9de5065430a9b1a61934f7e4a65474a7a11658db84a8b5b0c42baced6c33752"
+checksum = "f0e8f6b8a33244df75bddeef3ef1255552de517785f462a090ba218cf2abd93c"
 dependencies = [
  "ic-canister-sig-creation",
- "ic-certification 2.6.0",
+ "ic-certification",
  "ic-verify-bls-signature",
  "ic_principal",
  "serde",
@@ -1176,8 +1133,8 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "ic-canister-sig-creation",
- "ic-cdk 0.18.3",
- "ic-certification 2.6.0",
+ "ic-cdk 0.20.2",
+ "ic-certification",
  "ic-signature-verification",
  "identity_core",
  "identity_credential",
@@ -1211,9 +1168,9 @@ checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
 
 [[package]]
 name = "ic0"
-version = "0.25.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39a4ced1c92f952a12e554742ffa7d21752a02450930c3b76bea78a2f1b7ab16"
+checksum = "c77c8932bff1f09502d0d8c079d5a206a06afe523e35e816162cf4d30b5bf80d"
 
 [[package]]
 name = "ic_bls12_381"
@@ -1689,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1758,9 +1715,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1923,7 +1880,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.1.0",
+ "http",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2327,9 +2284,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,13 @@ serde_cbor = "0.11"
 serde_bytes = "0.11"
 anyhow = "1.0"
 candid = "0.10"
-ic-cdk = "0.18.3"
-ic-cdk-macros = "0.18.3"
-ic-certification = "2.2"
-ic-http-certification = "2.5"
+ic-cdk = "0.20.2"
+ic-cdk-macros = "0.20.2"
+ic-certification = "3.2"
+ic-http-certification = "3.2"
 ic-verifiable-credentials = { path = "rust-packages/ic-verifiable-credentials" }
 ic-canister-sig-creation = "1.3"
-ic-signature-verification = "0.2.0"
+ic-signature-verification = "0.3.0"
 
 [workspace.dependencies.serde]
 version = "1.0"

--- a/dummy-issuer/tests/dummy_issuer.rs
+++ b/dummy-issuer/tests/dummy_issuer.rs
@@ -34,7 +34,6 @@ enum CanisterCall {
 }
 
 mod api {
-    use ic_cdk::management_canister::CanisterId;
     use ic_verifiable_credentials::issuer_api::{
         GetCredentialRequest, IssueCredentialError, IssuedCredentialData, PrepareCredentialRequest,
         PreparedCredentialData,
@@ -46,7 +45,7 @@ mod api {
         pic: &PocketIc,
         method: &str,
         call_type: CanisterCall,
-        canister_id: CanisterId,
+        canister_id: Principal,
         request: Req,
         sender: Option<Principal>,
     ) -> Result<Succ, Err>
@@ -85,7 +84,7 @@ mod api {
 
     pub fn consent_message(
         pic: &PocketIc,
-        canister_id: CanisterId,
+        canister_id: Principal,
         request: Icrc21VcConsentMessageRequest,
         sender: Option<Principal>,
     ) -> Result<Icrc21ConsentInfo, Icrc21Error> {
@@ -101,7 +100,7 @@ mod api {
 
     pub fn derivation_origin(
         pic: &PocketIc,
-        canister_id: CanisterId,
+        canister_id: Principal,
         request: DerivationOriginRequest,
         sender: Option<Principal>,
     ) -> Result<DerivationOriginData, DerivationOriginError> {
@@ -117,7 +116,7 @@ mod api {
 
     pub fn prepare_credential(
         pic: &PocketIc,
-        canister_id: CanisterId,
+        canister_id: Principal,
         request: PrepareCredentialRequest,
         sender: Option<Principal>,
     ) -> Result<PreparedCredentialData, IssueCredentialError> {
@@ -133,7 +132,7 @@ mod api {
 
     pub fn get_credential(
         pic: &PocketIc,
-        canister_id: CanisterId,
+        canister_id: Principal,
         request: GetCredentialRequest,
         sender: Option<Principal>,
     ) -> Result<IssuedCredentialData, IssueCredentialError> {

--- a/dummy-relying-party/Cargo.toml
+++ b/dummy-relying-party/Cargo.toml
@@ -14,7 +14,7 @@ ic-cdk-macros.workspace = true
 serde.workspace = true
 serde_cbor.workspace = true
 sha2.workspace = true
-ic-http-certification = { workspace = true, features = ["serde"] }
+ic-http-certification.workspace = true
 base64.workspace = true
 lazy_static.workspace = true
 include_dir = { version = "0.7", features = ["glob"] }

--- a/dummy-relying-party/src/lib.rs
+++ b/dummy-relying-party/src/lib.rs
@@ -9,7 +9,7 @@ use ic_cdk::{
 use ic_http_certification::{
     DefaultCelBuilder, DefaultResponseCertification, DefaultResponseOnlyCelExpression, HeaderField,
     HttpCertification, HttpCertificationPath, HttpCertificationTree, HttpCertificationTreeEntry,
-    HttpRequest, HttpResponse,
+    HttpRequest, HttpResponse, StatusCode,
 };
 use include_dir::{Dir, include_dir};
 use lazy_static::lazy_static;
@@ -30,7 +30,7 @@ fn post_upgrade() {
 }
 
 #[query]
-fn http_request(req: HttpRequest) -> HttpResponse {
+fn http_request(req: HttpRequest) -> HttpResponse<'static> {
     asset_handler(&req)
 }
 
@@ -38,19 +38,18 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 
 #[derive(Debug, Clone)]
 struct HttpAssetResponse<'a> {
-    pub status_code: u16,
+    pub status_code: StatusCode,
     pub headers: Vec<HeaderField>,
     pub body: Cow<'a, [u8]>,
 }
 
-impl Into<HttpResponse> for HttpAssetResponse<'_> {
-    fn into(self) -> HttpResponse {
-        HttpResponse {
-            status_code: self.status_code,
-            headers: self.headers,
-            body: self.body.to_vec(),
-            upgrade: None,
-        }
+impl<'a> From<HttpAssetResponse<'a>> for HttpResponse<'a> {
+    fn from(response: HttpAssetResponse<'a>) -> Self {
+        HttpResponse::builder()
+            .with_status_code(response.status_code)
+            .with_headers(response.headers)
+            .with_body(response.body)
+            .build()
     }
 }
 
@@ -286,7 +285,7 @@ fn certify_asset_response(
 }
 
 // Handlers
-fn asset_handler(req: &HttpRequest) -> HttpResponse {
+fn asset_handler(req: &HttpRequest) -> HttpResponse<'static> {
     let req_path = req.get_path().expect("Failed to get req path");
 
     RESPONSES.with_borrow(|responses| {
@@ -309,7 +308,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse {
             };
 
             // extract the content encoding header
-            let content_encoding = req.headers.iter().find_map(|(name, value)| {
+            let content_encoding = req.headers().iter().find_map(|(name, value)| {
                 if name.to_lowercase() == "accept-encoding" {
                     Some(value)
                 } else {
@@ -361,7 +360,7 @@ fn asset_handler(req: &HttpRequest) -> HttpResponse {
 
 const IC_CERTIFICATE_HEADER: &str = "IC-Certificate";
 fn add_certificate_header(
-    response: &mut HttpResponse,
+    response: &mut HttpResponse<'_>,
     entry: &HttpCertificationTreeEntry,
     request_url: &str,
     expr_path: &[String],
@@ -374,7 +373,7 @@ fn add_certificate_header(
     });
     let expr_path = cbor_encode(&expr_path);
 
-    response.headers.push((
+    response.add_header((
         IC_CERTIFICATE_HEADER.to_string(),
         format!(
             "certificate=:{}:, tree=:{}:, expr_path=:{}:, version=2",
@@ -398,7 +397,7 @@ fn create_asset_response(
     headers.extend(additional_headers);
 
     HttpAssetResponse {
-        status_code: 200,
+        status_code: StatusCode::OK,
         headers,
         body: Cow::Borrowed(body),
     }


### PR DESCRIPTION
# Motivation

I'm trying to bump the IC-CDK within OpenChat, which also depends on this package. So in order to bump the CDK version within OC I first need to bump it here.

# Changes

Bumps ic-cdk and ic-cdk-macros to 0.20.2, ic-certification and ic-http-certification to 3.2.0, and ic-signature-verification to 0.3.2.
